### PR TITLE
Fix section offset calculation for capp-ucode

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ for i in $(seq $NUMBEROFTOCENTRIES) ; do
 	sectionfile[$sections]=${phb3file[$i]}
 	sectionsize[$sections]=$( stat -c %s ${sectionfile[$sections]} )
 	sectionoffset[$sections]=$(align $offset)
-	offset=$(( $offset + ${sectionsize[$sections]} ))
+	offset=$(( ${sectionoffset[$sections]} + ${sectionsize[$sections]} ))
 	$debug Adding section ${phb3file[$i]} size: ${sectionsize[$sections]} offset: ${sectionoffset[$sections]}
 	section=$sections
     fi


### PR DESCRIPTION
While calculating the offset of a capp-code section, the build.sh
script erroneously uses the unaligned-offset of the current section
instead of aligned-offset to update the offset variable. This can
introduce difference of 4K or more in the actual offset of ucode
section and the offset stored on the capp-ucode PNOR TOC
header. Currently offset variable is updated as:

   section_offset = 4k_align(offset)
   offset = offset + current_section_size

This is problematic as due to 4k-alignment, there is difference introduced
in value of section_offset and offset, which accumulates over each
iteration of the loop that calculates ucode-section offsets. Below is
an example:

Begin:
section_offset		 = 0x0
file_offset		 = 0x0 <- file offset of ucode-section
offset 			 = 0x0

Section 1: Size = 0x8E50
section_offset		 = 0x0000
file_offset    	 	 = 0x0000
offset [0x0000 + 0x8E59] = 0x8E50

Section 2: Size = 0x7108
section_offset		 = 0x9000
file_offset    	 	 = 0x9000
offset [0x8E50 + 0x7108] = 0xFF58

Section 3: Size = 0x7108
section_offset		 = 0x10000
file_offset    	 	 = 0x11000 <- Mismatch

As evident above the file_offset of Section-3 is 4-KiB further than
whats stored as the section offset in TOC header. This causes skiboot
to not load the capp-ucode lid at boot as it reads wrong eyecatcher &
version values. To fix this issue the patch updates the offset
calculation as:

   offset = 4k_align(offset) + current_section_size

Plugging the new expression in the problematic scenario described
earlier fixes the issue as illustrated below:

Section 1: Size = 0x8E50
section_offset		 = 0x0000
file_offset    	 	 = 0x0000
offset [0x0000 + 0x8E59] = 0x8E50

Section 2: Size = 0x7108
section_offset		 = 0x9000
file_offset    	 	 = 0x9000
offset [0x9000 + 0x7108] = 0x10180

Section 3: Size = 0x7108
section_offset		 = 0x11000
file_offset    	 	 = 0x11000 <- Match

Signed-off-by: Vaibhav Jain <vaibhav@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/capp-ucode/2)
<!-- Reviewable:end -->
