### PR TITLE
Add CAPP ucode binary for POWER9 DD-2.1 chips

### DIFF
--- a/CAPPUC_P9N21.bin
+++ b/CAPPUC_P9N21.bin
@@ -1,0 +1,1 @@
+CAPPUC_P9N20.bin

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,9 @@ phb3=$(( $phb3 + 1))
 phb3id[$phb3]=$(( 0x200d1 ))
 phb3file[$phb3]="CAPPUC_P9N20.bin"
 
+phb3=$(( $phb3 + 1))
+phb3id[$phb3]=$(( 0x201d1 ))
+phb3file[$phb3]="CAPPUC_P9N21.bin"
 
 debug=true
 if [ -n "$DEBUG" ] ; then


### PR DESCRIPTION
This updates the 'build.sh' to add new CAPP ucode section for
phb4-chipid == 0x201D1 which indicates POWER9 DD-2.1 processor.

Right now DD-2.1 shares the same ucode as DD-2.0 processor hence the
new ucode binary file 'CAPPUC_P9N21.bin' is introduced as a soft-link to
the existing 'CAPPUC_P9N20.bin' file.

When 'build.sh' is run the contents of 'CAPPUC_P9N21.bin' will match
against 'CAPPUC_P9N20.bin', So 'build.sh' will just add an entry to the
table of contents pointing it to existing contents of
'CAPPUC_P9N20.bin' previously added to the 'cappucode.bin'

Signed-off-by: Vaibhav Jain <vaibhav@linux.vnet.ibm.com>