### PR TITLE
Add CAPP ucode binary for POWER9 DD-2.2 chips

### DIFF
--- a/CAPPUC_P9N22.bin
+++ b/CAPPUC_P9N22.bin
@@ -1,0 +1,1 @@
+CAPPUC_P9N20.bin

--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,10 @@ phb3=$(( $phb3 + 1))
 phb3id[$phb3]=$(( 0x201d1 ))
 phb3file[$phb3]="CAPPUC_P9N21.bin"
 
+phb3=$(( $phb3 + 1))
+phb3id[$phb3]=$(( 0x202d1 ))
+phb3file[$phb3]="CAPPUC_P9N22.bin"
+
 debug=true
 if [ -n "$DEBUG" ] ; then
     debug=echo


### PR DESCRIPTION
This updates the 'build.sh' to add new CAPP ucode section for
phb4-chipid == 0x202D1 which indicates POWER9 DD-2.2 processor.

Right now DD-2.2 shares the same ucode as DD-2.0 processor hence the
new ucode binary file 'CAPPUC_P9N22.bin' is introduced as a soft-link to
the existing 'CAPPUC_P9N20.bin' file.

Signed-off-by: Vaibhav Jain <vaibhav@linux.vnet.ibm.com>