### PR TITLE
doc: Updated the README.md with info on DEBUG env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ To build, do:
 
 Which will create a single file cappucode.bin.
 
-DEBUG env variable can also be set to to know which ucode blobs are being
+DEBUG env variable can also be set to know which ucode blobs are being
 merged to generate the CAPP ucode blob.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is the CAPP microcode for POWER8 and POWER9 systems.
+This is the CAPP microcode for **POWER8** and **POWER9** systems.
 
 This needs to be loaded into the CAPP unit on a POWER8 or POWER9 using
 skiboot for a system to use CAPI.
@@ -11,3 +11,6 @@ To build, do:
    ./build.sh
 
 Which will create a single file cappucode.bin.
+
+DEBUG env variable can also be set to to know which ucode blobs are being
+merged to generate the CAPP ucode blob.


### PR DESCRIPTION
Add info on the DEBUG env variable that forces the 'build.sh' script
to generate verbose output of which CAPP ucode bin-blobs are being
merged or de-duplicated.

Signed-off-by: Vaibhav Jain <vaibhav@linux.vnet.ibm.com>