### PR TITLE
travis-ci: Update the build script to use the DEBUG var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 # It's not really C, but this is the closest Travis has
 language: c
 
-script: ./build.sh
+script: DEBUG=1 ./build.sh


### PR DESCRIPTION
Update the travis-ci script '.travis.yml' to also set the DEBUG env
variable so that 'build.sh' dumps info on what capp-ucode bin blobs
are being merged/de-duplicated.

Signed-off-by: Vaibhav Jain <vaibhav@linux.vnet.ibm.com>